### PR TITLE
Add `endkey` and other enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Parler pages are indexed by `startkey` and each response returns a `next` value 
 Let's look at a user's post history. First we find the user's `id` by fetching their profile. 
 ```
 profile = pyrler.Profile()
-profile_response = profile.get_user_profile(username="SeanHannity")
+profile_response = profile.get_user_profile(username="AltCyberCommand")
 user_id = profile_response.json().get("id")
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,28 +26,36 @@ Both stdout and file handlers can be enabled together.
 
 ### Pagination
 
-Pyrler pulls only the first page of results by default.  To use pagination pass a function the `follow` arg.
+Pyrler pulls only the first page of results by default.  To use pagination pass a truthy value to the `follow` argument.
 
 Parler pages are indexed by `startkey` and each response returns a `next` value used to access the next page.
 
 Let's look at a user's post history. First we find the user's `id` by fetching their profile. 
 ```
 profile = pyrler.Profile()
-profile_response = profile.get_user_profile(username="AltCyberCommand")
+profile_response = profile.get_user_profile(username="SeanHannity")
 user_id = profile_response.json().get("id")
 ```
 
 Now we fetch their post history starting with the first page of data.
 ```
 p = pyrler.Post()
-r = p.get_user_posts(id=user_id, startkey=None, follow=True)
+r = p.get_user_posts(user_id=user_id, startkey=None, follow=True)
 ```
+
+You can specify the `endkey` argument to stop pagination after a certain time. `endkey` must be formatted as a timestamp (as Parler returns for its `prev`/`next` keys). For example:
+
+```
+r = p.get_user_posts(user_id=user_id, startkey=None, endkey="2021-02-16T14:53:30.429Z_322497", follow=True)
+```
+
+Note that you may still receive results earlier than `endkey` if they are on a page whose last result is _after_ `endkey`. `endkey` simply prevents pagination from continuing further back in time.
 
 Wow. Much shitposting.
 
 ## Methods
 
-Take a look at `pyrler.core.pyrler.py` for the complete list of methods.
+Take a look at `pyrler/core/pyrler.py` for the complete list of methods.
 
 Methods return a dict by default and a list of dicts when `follow=True`.
 

--- a/pyrler/core/pyrler.py
+++ b/pyrler/core/pyrler.py
@@ -862,42 +862,45 @@ class Post(_Parler):
         return self._get_request(route=route, **kwargs)
 
     @paginate
-    def get_user_posts(self, post_id=None, startkey=None, follow=None, **kwargs):
+    def get_user_posts(self, user_id=None, post_id=None, startkey=None, follow=None, **kwargs):
         """
         Returns posts created by a user.
-        :param id: User ID
+        :param user_id: User ID
         :param startkey:
         :param kwargs:
         :return:
         """
+        # We fallback to `post_id` to avoid breaking API changes
         route = "/v1/post/creator"
-        request_params = {"id": post_id, "startkey": startkey}
+        request_params = {"id": user_id or post_id, "startkey": startkey}
         return self._get_request(route=route, params=request_params, **kwargs)
 
     @paginate
-    def get_liked_posts(self, post_id=None, startkey=None, follow=None, **kwargs):
+    def get_liked_posts(self, user_id=None, post_id=None, startkey=None, follow=None, **kwargs):
         """
         Returns posts liked by a user.
-        :param post_id: post ID
+        :param user_id: user ID
         :param startkey:
         :param kwargs:
         :return:
         """
+        # We fallback to `post_id` to avoid breaking API changes
         route = "/v1/post/creator/liked"
-        request_params = {"id": post_id, "startkey": startkey}
+        request_params = {"id": user_id or post_id, "startkey": startkey}
         return self._get_request(route=route, params=request_params, **kwargs)
 
     @paginate
-    def get_creator_media(self, post_id=None, startkey=None, follow=None, **kwargs):
+    def get_creator_media(self, user_id=None, post_id=None, startkey=None, follow=None, **kwargs):
         """
         Returns media posted by a user.
-        :param post_id: User ID
+        :param user_id: User ID
         :param startkey:
         :param kwargs:
         :return:
         """
+        # We fallback to `post_id` to avoid breaking API changes
         route = "/v1/post/creator/media"
-        request_params = {"id": post_id, "startkey": startkey}
+        request_params = {"id": user_id or post_id, "startkey": startkey}
         return self._get_request(route=route, params=request_params, **kwargs)
 
     @paginate

--- a/pyrler/utilities/wrappers.py
+++ b/pyrler/utilities/wrappers.py
@@ -15,6 +15,13 @@ def paginate(func):
             else:
                 startkey = None
 
+            # End at the user defined index otherwise go back as far as possible.
+            if kwargs.get("endkey"):
+                endkey = kwargs.get("endkey")
+                del kwargs["endkey"]
+            else:
+                endkey = None
+
             # Fetch pages until we've got them or something breaks.
             while True:
                 r = func(startkey=startkey, *args, **kwargs)
@@ -39,7 +46,12 @@ def paginate(func):
                     logger.debug("Next page could not be returned. Check requests debug log.")
                     break
 
+                if endkey is not None and r.json().get("next") < endkey:
+                    logger.debug("Next page is earlier than endkey!")
+                    break
+
                 startkey = r.json().get("next")
+            
             return data
         else:
             return func(*args, **kwargs)

--- a/tests/main.py
+++ b/tests/main.py
@@ -1,0 +1,16 @@
+import unittest
+from pyrler.core import pyrler
+
+class TestUserMethods(unittest.TestCase):
+    def test_user_posts(self):
+        profile = pyrler.Profile()
+        profile_response = profile.get_user_profile(username="SeanHannity")
+        user_id = profile_response.json().get("id")
+        p = pyrler.Post()
+        out = p.get_user_posts(post_id=user_id, follow=True, endkey="2021-02-20T14:53:30.429Z_322497")
+        all_posts = sum([k.json()["posts"] for k in out], [])
+        print(f"Found {len(all_posts)} posts from Sean Hannity")
+        self.assertGreater(len(all_posts), 10)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
There are a few changes in here that are a bit opinionated; for example, I changed the argument from `post_id` to `user_id` in functions where the arg should specify a user (but I did the change in such a way that no one's code will break).

The big change here is the addition of `endkey`, which allows pagination to stop after a certain point.

TODO (for either this PR or future ones):

- [ ] Add tests for more endpoints
- [ ] Add more error resiliency (it doesn't seem too bad right now; afaik, it retries on 500's, for example)